### PR TITLE
Read java path from environment variable if set

### DIFF
--- a/cort/core/documents.py
+++ b/cort/core/documents.py
@@ -9,6 +9,7 @@ import logging
 
 from cort.core import mentions
 from cort.core import spans
+from cort.core.util import get_java_path
 
 import StanfordDependencies
 
@@ -396,7 +397,7 @@ class CoNLLDocument(Document):
                                           temp_pos,
                                           temp_tokens)
                   for span in sentence_spans]
-        sd = StanfordDependencies.get_instance()
+        sd = StanfordDependencies.get_instance(java_command=get_java_path())
         dep_trees = sd.convert_trees(
             [parse.replace("NOPARSE", "S") for parse in parses],
         )

--- a/cort/core/util.py
+++ b/cort/core/util.py
@@ -19,3 +19,9 @@ def clean_via_pos(tokens, pos):
     """
     return [token for token, pos in zip(tokens, pos)
             if pos not in ["DT", "POS"]]
+
+
+def get_java_path():
+    if "JAVA_HOME" in os.environ:
+        return os.path.join(os.environ["JAVA_HOME"], "bin", "java")
+    return "java"


### PR DESCRIPTION
StanfordDependencies.get_instance() tries to run Java with the command "java" by default. This leads to problems if the system-wide Java version is too old to run the latest CoreNLP version. This can be fixed by using the JAVA_HOME environment variable if it is set.

See: https://github.com/dmcc/PyStanfordDependencies/issues/17
